### PR TITLE
fix: 別origin の frame ページ内リンクテキストをコピーできない問題を修正

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -13,8 +13,7 @@
 		"scripting",
 		"storage",
 		"contextMenus",
-		"notifications",
-		"activeTab"
+		"notifications"
 	],
 
 	"host_permissions": [

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -20,6 +20,16 @@
 		"<all_urls>"
 	],
 
+	"content_scripts": [{
+		"matches": [
+			"<all_urls>"
+		],
+		"all_frames": true,
+		"js": [
+			"search_link_texts.js"
+		]
+	}],
+
 	"background": {
 		"service_worker": "background.js"
 	}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -17,6 +17,10 @@
 		"activeTab"
 	],
 
+	"host_permissions": [
+		"<all_urls>"
+	],
+
 	"background": {
 		"service_worker": "background.js"
 	}


### PR DESCRIPTION
activeTab 権限があっても、異なる origin の frame へはアクセスできないため

## おまけ
- feat: 同じリンクURLが複数あった場合に選択画面を出さずにコピーする
  - すでにページへのフルアクセス権限を要求しているので最初から全ページでcontent_script を実行しておく
